### PR TITLE
Feature/image sizes

### DIFF
--- a/app/assets/javascripts/event_form.js.erb
+++ b/app/assets/javascripts/event_form.js.erb
@@ -165,7 +165,7 @@ function removePicture(){
 
 /**
  * Ensure file selected is valid
- * (under 3MB and a jpeg or png)
+ * (under 5MB and a jpeg or png)
  * If not prevent form completion
  * and give the user an error message.
  * @param input (file input)
@@ -183,7 +183,7 @@ function validateFileInput(input){
     var error = false;
     var message = '';
     var size_mb = file.size/1024/1024;
-    if (size_mb > 3 ) {
+    if (size_mb > 5 ) {
         error = true;
         message += i18n.events.form.picture.too_big + " ";
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,12 @@ class ApplicationController < ActionController::Base
 
   protected
 
+  ADDITIONAL_AHOY_FILTERS = [ :blank_file, :signature, :wet_signature, :file, :image, :logo, :picture ]
+  AHOY_PARAM_FILTER       = ActionDispatch::Http::ParameterFilter.new(ADDITIONAL_AHOY_FILTERS)
+
   def track
-    ahoy.track "#{controller_name}##{action_name}", request.filtered_parameters
+    ahoy_params = AHOY_PARAM_FILTER.filter(request.filtered_parameters)
+    ahoy.track "Processed #{controller_name}##{action_name}", ahoy_params
   end
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale
@@ -36,4 +40,5 @@ class ApplicationController < ActionController::Base
       redirect_to root_path, alert: 'Only authorised users can edit events!'
     end
   end
+
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,11 +8,11 @@ class Event < ActiveRecord::Base
   belongs_to :event_series
   has_and_belongs_to_many :categories
   has_many :comments
-  has_attached_file :picture, styles: { original: '500x500>', thumb: '100x100>'}, default_url: 'images/:st'
+  has_attached_file :picture, styles: { original: '1500x1500>', large: '500x500>', thumb: '100x100>', some: '1000x500#' }, default_url: 'images/:st'
 
   validates_attachment_content_type :picture, :content_type => /\Aimage/
   validates_attachment_file_name :picture, matches: [/png\Z/i, /jpe?g\Z/i]
-  validates_with AttachmentSizeValidator, attributes: :picture, less_than:  3.megabytes
+  validates_with AttachmentSizeValidator, attributes: :picture, less_than:  5.megabytes
 
   scope :published, -> { where(published: true) }
   scope :future, -> { where('events.end_time > ?', DateTime.now) }

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -7,7 +7,7 @@ class EventSeries < ActiveRecord::Base
             :day_array, :rule, :start_date, :start_time, :end_time, :expiry, presence: true
 
   # TODO: this duplicates functionality in Event.rb so it should be refactored, but modularization caused constant load errors
-  has_attached_file :picture, styles: { original: '500x500>', thumb: '100x100>'}, default_url: 'images/:st'
+  has_attached_file :picture, styles: { original: '1500x1500>', large: '500x500>', thumb: '100x100>', some: '1000x500#' }, default_url: 'images/:st'
   validates_attachment_content_type :picture, :content_type => /\Aimage/
   validates_attachment_file_name :picture, matches: [/png\Z/i, /jpe?g\Z/i]
   validates_with AttachmentSizeValidator, attributes: :picture, less_than:  3.megabytes

--- a/app/presenters/event_presenter.rb
+++ b/app/presenters/event_presenter.rb
@@ -55,7 +55,7 @@ class EventPresenter
 
   def fb_image
     if @object.best_picture.present?
-      fb_tag('image', asset_url(@object.best_picture.url(:original)))
+      fb_tag('image', asset_url(@object.best_picture.url(:some)))
     else
       ''
     end

--- a/app/views/calendar/_highlights.html.erb
+++ b/app/views/calendar/_highlights.html.erb
@@ -6,7 +6,7 @@
         <div class="col-xs-4">
           <% if event.best_picture.present? %>
               <%= link_to event do %>
-                  <%= image_tag event.best_picture.url(:original), class: 'img-responsive center-block' %>
+                  <%= image_tag event.best_picture.url(:large), class: 'img-responsive center-block' %>
               <% end %>
           <% end %>
         </div>

--- a/app/views/event_series/show.erb
+++ b/app/views/event_series/show.erb
@@ -1,6 +1,6 @@
 <div class="event_show">
   <h1><%= @event_series.title %></h1>
-  <%= image_tag @event_series.picture.url(:original) if @event_series.picture.present? %>
+  <%= image_tag @event_series.picture.url(:large) if @event_series.picture.present? %>
   <h4>
     <%= link_to(@event_series.location.full_address, location_path(@event_series.location)) %>
   </h4>

--- a/app/views/events/show.erb
+++ b/app/views/events/show.erb
@@ -10,7 +10,9 @@
   <h1><%= @event.title %></h1>
   <%# If this event has a picture, show that, if not and it's part of a series with a picture, show that instead %>
   <% if @event.best_picture.present? %>
-    <%= image_tag @event.best_picture.url(:original), title: @event.title, alt: @event.title %>
+    <a href="<%= @event.best_picture.url(:original)%>" target="_blank">
+    <%= image_tag @event.best_picture.url(:large), title: @event.title, alt: @event.title %>
+    </a>
   <% end %>
   <h3>
     <%= format_daterange(@event.start_time, @event.end_time) %>


### PR DESCRIPTION
Fixes #402 (dvs kun den del med at kunne lægge et større billede ind)

Efter at have omdefineret billeder, skal man lægge dette ind i `public/system/paperclip_attachments.yml`

(fjern alle de styles som IKKE er genererede)

```
---
:Event:
  :picture:
  - :large
  - :original
  - :some
  - :thumb
:EventSeries:
  :picture:
  - :large
  - :original
  - :some
  - :thumb
```

Og generere nye billeder med:

```
ulimit -n 10000
rake paperclip:refresh:missing_styles
```

This also fixed the endless `UndefinedConversionError` error when creating an event locally with an image.