### PR TITLE
Remove user supplied data from flash message

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -21,11 +21,11 @@ class EventsController < ApplicationController
       series_params = event_params.merge(event_params[:event_series]).except(:event_series, :featured)
       @event_series = EventSeries.new(series_params)
       saved = @event_series.save
-      notice = I18n.t('event_series.created', link: url_for(@event_series), name: @event_series.name, num_events: @event_series.coming_events.size)
+      notice = I18n.t('event_series.created', link: url_for(@event_series), num_events: @event_series.coming_events.size)
     else
       @event = Event.new(event_params.except('event_series'))
       saved = @event.save
-      notice = I18n.t('events.event_created', link: url_for(@event), name: @event.name)
+      notice = I18n.t('events.event_created', link: url_for(@event))
     end
 
     respond_to do |format|
@@ -47,7 +47,7 @@ class EventsController < ApplicationController
       if @event.update(user_params)
         destroy_image?
         format.html {
-          redirect_to root_path, notice: I18n.t('events.event_updated', link: url_for(@event), name: @event.name)
+          redirect_to root_path, notice: I18n.t('events.event_updated', link: url_for(@event))
         }
         format.json { head :no_content }
       else

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -129,8 +129,8 @@ da:
       edit_event: "Redigerer begivenhed"
     new:
       new_event: "Opret begivenhed"
-    event_updated: "Ændringer til <a href=\"%{link}\" class='alert-link'>%{name}</a> gemt!"
-    event_created: "Event <a href=\"%{link}\" class='alert-link'>%{name}</a> oprettet!"
+    event_updated: "Ændringer til <a href=\"%{link}\" class='alert-link'>din event</a> gemt!"
+    event_created: "<a href=\"%{link}\" class='alert-link'>Din event</a> er oprettet!"
     event_deleted: "Event slettet"
     show:
       link: "Mere info"
@@ -299,8 +299,8 @@ da:
                   Ved at oprette en serie med en bestemt regel opretter du flere events på de datoer
                   givet i reglen. Efterfølgende kan du vælge at redigere disse forekomster enkeltvis
                   eller samlede ved at redigere i selv serien.
-    created: "Serie <a href=\"%{link}\">%{name}</a> oprettet med %{num_events} forekomster!"
-    updated: "Serie <a href=\"%{link}\">%{name}</a> med %{num_events} forekomster opdateret."
+    created: "<a href=\"%{link}\">Serie</a> oprettet med %{num_events} forekomster!"
+    updated: "<a href=\"%{link}\">Serie</a> med %{num_events} forekomster opdateret."
     deleted: "Serie %{name} og %{num_events} forekomster slettet."
     events_deleted: "%{number} events slettet"
     form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -128,8 +128,8 @@ en:
       edit_event: "Editing event"
     new:
       new_event: "New event"
-    event_updated: "Changes to <a href=\"%{link}\" class='alert-link'>%{name}</a> saved!"
-    event_created: "Event <a href=\"%{link}\" class='alert-link'>%{name}</a> created!"
+    event_updated: "Changes to <a href=\"%{link}\" class='alert-link'>your event</a> saved!"
+    event_created: "<a href=\"%{link}\" class='alert-link'>Event</a> created!"
     event_deleted: "Event deleted"
     show:
       link: "More info"
@@ -248,8 +248,8 @@ en:
               You are about to create an event series. This will create a number of events
               defined by the rule you specify. You can then choose to edit the events individually
               or all at once by editing this series.
-    created: "<a href=\"%{link}\">%{name}</a> created with %{num_events} occurrences"
-    updated: "%{num_events} occurrences of <a href=\"%{link}\">%{name}</a> updated"
+    created: "<a href=\"%{link}\">Series</a> created with %{num_events} occurrences"
+    updated: "%{num_events} occurrences of <a href=\"%{link}\">your series</a> updated"
     deleted: "The series %{name} with %{num_events} occurrences has been deleted"
     events_deleted: "%{number} events slettet"
     form:


### PR DESCRIPTION
![screenshot 2018-12-18 at 21 27 03](https://user-images.githubusercontent.com/1145457/50181335-5c078b80-030c-11e9-86f1-e235a5dcafd3.png)
![screenshot 2018-12-18 at 21 27 13](https://user-images.githubusercontent.com/1145457/50181339-5f9b1280-030c-11e9-822f-dbb7337281ec.png)
![screenshot 2018-12-18 at 21 27 22](https://user-images.githubusercontent.com/1145457/50181344-632e9980-030c-11e9-81e6-08cea745b29a.png)
![screenshot 2018-12-18 at 21 27 41](https://user-images.githubusercontent.com/1145457/50181351-64f85d00-030c-11e9-9b51-51a327ade819.png)
![screenshot 2018-12-18 at 21 29 00](https://user-images.githubusercontent.com/1145457/50181354-675ab700-030c-11e9-9d52-03f583bc7cef.png)


Duk Op has an XSS vulnerability whereby a user supplied string (event titles) are rendered to HTML in an alert box with sanitisation. This PR fixes the issue by removing the user supplied string from the notification. 